### PR TITLE
Cache partial face shapes and voxel shape operations in BlockFaceUtils

### DIFF
--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/board/CopycatBoardBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/board/CopycatBoardBlock.java
@@ -8,6 +8,7 @@ import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopyca
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.model.ScaledBlockAndTintGetter;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.content.contraptions.StructureTransform;
 import com.simibubi.create.content.schematics.requirement.ISpecialBlockItemRequirement;
@@ -63,6 +64,7 @@ public class CopycatBoardBlock extends WaterloggedMultiStateCopycatBlock impleme
     public static BooleanProperty WEST = BlockStateProperties.WEST;
     public static final Map<Direction, BooleanProperty> PROPERTY_BY_DIRECTION = PipeBlock.PROPERTY_BY_DIRECTION;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
+    private final Map<String, Map<Direction, VoxelShape>> partialFaceCache = new HashMap<>();
 
     public CopycatBoardBlock(Properties properties) {
         super(properties);
@@ -174,6 +176,13 @@ public class CopycatBoardBlock extends WaterloggedMultiStateCopycatBlock impleme
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState pState, @NotNull BlockGetter pLevel, @NotNull BlockPos pPos, @NotNull CollisionContext pContext) {
         return Objects.requireNonNull(this.shapesCache.get(pState));
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/board/CopycatBoardBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/board/CopycatBoardBlock.java
@@ -1,6 +1,7 @@
 package com.copycatsplus.copycats.content.copycat.board;
 
 import com.copycatsplus.copycats.CCShapes;
+import com.copycatsplus.copycats.content.copycat.half_layer.CopycatHalfLayerBlock;
 import com.copycatsplus.copycats.foundation.copycat.CopycatExternalContext;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.ICustomCTBlocking;
@@ -64,7 +65,10 @@ public class CopycatBoardBlock extends WaterloggedMultiStateCopycatBlock impleme
     public static BooleanProperty WEST = BlockStateProperties.WEST;
     public static final Map<Direction, BooleanProperty> PROPERTY_BY_DIRECTION = PipeBlock.PROPERTY_BY_DIRECTION;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
-    private final Map<String, Map<Direction, VoxelShape>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
+
+    public static record FaceData(String property, Direction direction) {
+    }
 
     public CopycatBoardBlock(Properties properties) {
         super(properties);
@@ -77,6 +81,20 @@ public class CopycatBoardBlock extends WaterloggedMultiStateCopycatBlock impleme
                 .setValue(WEST, false)
         );
         this.shapesCache = this.getShapeForEachState(CopycatBoardBlock::calculateMultifaceShape);
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        BlockState state = defaultBlockState()
+                .setValue(UP, true)
+                .setValue(DOWN, true)
+                .setValue(NORTH, true)
+                .setValue(SOUTH, true)
+                .setValue(EAST, true)
+                .setValue(WEST, true);
+        for (String property : storageProperties()) {
+            for (Direction face : Direction.values()) {
+                builder.put(new FaceData(property, face), BlockFaceUtils.getPartialFaceShape(null, state, property, face));
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -180,9 +198,11 @@ public class CopycatBoardBlock extends WaterloggedMultiStateCopycatBlock impleme
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, face),
+                Shapes.empty()
+        ));
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/byte_panel/CopycatBytePanelBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/byte_panel/CopycatBytePanelBlock.java
@@ -1,5 +1,6 @@
 package com.copycatsplus.copycats.content.copycat.byte_panel;
 
+import com.copycatsplus.copycats.content.copycat.board.CopycatBoardBlock;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
@@ -57,7 +58,10 @@ public class CopycatBytePanelBlock extends WaterloggedMultiStateCopycatBlock imp
     public static BooleanProperty TOP_RIGHT = BooleanProperty.create("top_right");
     public static DirectionProperty FACING = BlockStateProperties.FACING;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
-    private final Map<String, Map<Direction, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
+
+    public static record FaceData(String property, Direction facing, Direction direction) {
+    }
 
     public CopycatBytePanelBlock(Properties properties) {
         super(properties);
@@ -69,6 +73,21 @@ public class CopycatBytePanelBlock extends WaterloggedMultiStateCopycatBlock imp
                 .setValue(FACING, Direction.DOWN)
         );
         this.shapesCache = this.getShapeForEachState(CopycatBytePanelBlock::calculateMultiFaceShape);
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        BlockState state = defaultBlockState()
+                .setValue(BOTTOM_LEFT, true)
+                .setValue(BOTTOM_RIGHT, true)
+                .setValue(TOP_LEFT, true)
+                .setValue(TOP_RIGHT, true);
+        for (String property : storageProperties()) {
+            for (Direction facing : FACING.getPossibleValues()) {
+                state = state.setValue(FACING, facing);
+                for (Direction face : Direction.values()) {
+                    builder.put(new FaceData(property, facing, face), BlockFaceUtils.getPartialFaceShape(null, state, property, face));
+                }
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -164,10 +183,11 @@ public class CopycatBytePanelBlock extends WaterloggedMultiStateCopycatBlock imp
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(state.getValue(FACING), d -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, state.getValue(FACING), face),
+                Shapes.empty()
+        ));
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/byte_panel/CopycatBytePanelBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/byte_panel/CopycatBytePanelBlock.java
@@ -4,6 +4,7 @@ import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.math.OctahedralGroup;
 import com.simibubi.create.content.contraptions.StructureTransform;
@@ -56,6 +57,7 @@ public class CopycatBytePanelBlock extends WaterloggedMultiStateCopycatBlock imp
     public static BooleanProperty TOP_RIGHT = BooleanProperty.create("top_right");
     public static DirectionProperty FACING = BlockStateProperties.FACING;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
+    private final Map<String, Map<Direction, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
 
     public CopycatBytePanelBlock(Properties properties) {
         super(properties);
@@ -158,6 +160,14 @@ public class CopycatBytePanelBlock extends WaterloggedMultiStateCopycatBlock imp
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState pState, @NotNull BlockGetter pLevel, @NotNull BlockPos pPos, @NotNull CollisionContext pContext) {
         return Objects.requireNonNull(this.shapesCache.get(pState));
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(state.getValue(FACING), d -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/bytes/CopycatByteBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/bytes/CopycatByteBlock.java
@@ -1,6 +1,7 @@
 package com.copycatsplus.copycats.content.copycat.bytes;
 
 import com.copycatsplus.copycats.Copycats;
+import com.copycatsplus.copycats.content.copycat.board.CopycatBoardBlock;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
@@ -56,7 +57,10 @@ public class CopycatByteBlock extends WaterloggedMultiStateCopycatBlock implemen
     public static BooleanProperty BOTTOM_SE = BooleanProperty.create("bottom_southeast");
     public static BooleanProperty BOTTOM_SW = BooleanProperty.create("bottom_southwest");
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
-    private final Map<String, Map<Direction, VoxelShape>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
+
+    public static record FaceData(String property, Direction direction) {
+    }
 
     public static final List<Byte> allBytes;
     public static final Map<String, Byte> byteMap;
@@ -86,6 +90,22 @@ public class CopycatByteBlock extends WaterloggedMultiStateCopycatBlock implemen
                 .setValue(BOTTOM_SW, false)
         );
         this.shapesCache = this.getShapeForEachState(CopycatByteBlock::calculateMultiFaceShape);
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        BlockState state = defaultBlockState()
+                .setValue(TOP_NE, true)
+                .setValue(TOP_NW, true)
+                .setValue(TOP_SE, true)
+                .setValue(TOP_SW, true)
+                .setValue(BOTTOM_NE, true)
+                .setValue(BOTTOM_NW, true)
+                .setValue(BOTTOM_SE, true)
+                .setValue(BOTTOM_SW, true);
+        for (String property : storageProperties()) {
+            for (Direction face : Direction.values()) {
+                builder.put(new FaceData(property, face), BlockFaceUtils.getPartialFaceShape(null, state, property, face));
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -159,9 +179,11 @@ public class CopycatByteBlock extends WaterloggedMultiStateCopycatBlock implemen
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, face),
+                Shapes.empty()
+        ));
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/bytes/CopycatByteBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/bytes/CopycatByteBlock.java
@@ -5,6 +5,7 @@ import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.copycatsplus.copycats.utility.MathUtils;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.math.OctahedralGroup;
@@ -55,6 +56,7 @@ public class CopycatByteBlock extends WaterloggedMultiStateCopycatBlock implemen
     public static BooleanProperty BOTTOM_SE = BooleanProperty.create("bottom_southeast");
     public static BooleanProperty BOTTOM_SW = BooleanProperty.create("bottom_southwest");
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
+    private final Map<String, Map<Direction, VoxelShape>> partialFaceCache = new HashMap<>();
 
     public static final List<Byte> allBytes;
     public static final Map<String, Byte> byteMap;
@@ -153,6 +155,13 @@ public class CopycatByteBlock extends WaterloggedMultiStateCopycatBlock implemen
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState pState, @NotNull BlockGetter pLevel, @NotNull BlockPos pPos, @NotNull CollisionContext pContext) {
         return Objects.requireNonNull(this.shapesCache.get(pState));
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/cogwheel/CopycatCogWheelBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/cogwheel/CopycatCogWheelBlock.java
@@ -29,6 +29,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -148,6 +149,11 @@ public class CopycatCogWheelBlock extends CogWheelBlock implements IMultiStateCo
     public void playerWillDestroy(@NotNull Level level, @NotNull BlockPos pos, @NotNull BlockState state, @NotNull Player player) {
         super.playerWillDestroy(level, pos, state, player);
         IMultiStateCopycatBlock.super.playerWillDestroy(level, pos, state, player);
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return state.getFaceOcclusionShape(level, BlockPos.ZERO, face);
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/half_layer/CopycatHalfLayerBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/half_layer/CopycatHalfLayerBlock.java
@@ -12,6 +12,7 @@ import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopyca
 import com.copycatsplus.copycats.foundation.copycat.model.ScaledBlockAndTintGetter;
 import com.copycatsplus.copycats.foundation.copycat.multistate.MaterialItemStorage;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.copycatsplus.copycats.utility.BlockUtils;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.math.OctahedralGroup;
@@ -50,9 +51,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 import static net.minecraft.core.Direction.Axis;
@@ -68,6 +67,10 @@ public class CopycatHalfLayerBlock extends WaterloggedMultiStateCopycatBlock imp
     public static final IntegerProperty POSITIVE_LAYERS = IntegerProperty.create("positive_layers", 0, 8);
     public static final IntegerProperty NEGATIVE_LAYERS = IntegerProperty.create("negative_layers", 0, 8);
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
+    private final Map<String, Map<FaceData, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
+
+    private static record FaceData(Axis axis, Half half, int layers) {
+    }
 
     public CopycatHalfLayerBlock(Properties pProperties) {
         super(pProperties);
@@ -372,6 +375,14 @@ public class CopycatHalfLayerBlock extends WaterloggedMultiStateCopycatBlock imp
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState pState, @NotNull BlockGetter pLevel, @NotNull BlockPos pPos, @NotNull CollisionContext pContext) {
         return Objects.requireNonNull(this.shapesCache.get(pState));
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(new FaceData(state.getValue(AXIS), state.getValue(HALF), state.getValue(property.equals(NEGATIVE_LAYERS.getName()) ? NEGATIVE_LAYERS : POSITIVE_LAYERS)), d -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/half_layer/CopycatHalfLayerBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/half_layer/CopycatHalfLayerBlock.java
@@ -67,9 +67,9 @@ public class CopycatHalfLayerBlock extends WaterloggedMultiStateCopycatBlock imp
     public static final IntegerProperty POSITIVE_LAYERS = IntegerProperty.create("positive_layers", 0, 8);
     public static final IntegerProperty NEGATIVE_LAYERS = IntegerProperty.create("negative_layers", 0, 8);
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
-    private final Map<String, Map<FaceData, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
 
-    private static record FaceData(Axis axis, Half half, int layers) {
+    private static record FaceData(String property, Axis axis, Half half, int layers, Direction face) {
     }
 
     public CopycatHalfLayerBlock(Properties pProperties) {
@@ -81,6 +81,19 @@ public class CopycatHalfLayerBlock extends WaterloggedMultiStateCopycatBlock imp
                 .setValue(NEGATIVE_LAYERS, 0)
         );
         this.shapesCache = this.getShapeForEachState(CopycatHalfLayerBlock::calculateMultiFaceShape);
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        for (String property : storageProperties()) {
+            for (Axis axis : AXIS.getPossibleValues()) {
+                for (Half half : HALF.getPossibleValues()) {
+                    for (int layers : POSITIVE_LAYERS.getPossibleValues()) {
+                        for (Direction face : Direction.values()) {
+                            builder.put(new FaceData(property, axis, half, layers, face), BlockFaceUtils.getPartialFaceShape(null, defaultBlockState().setValue(AXIS, axis).setValue(HALF, half).setValue(NEGATIVE_LAYERS, layers).setValue(POSITIVE_LAYERS, layers), property, face));
+                        }
+                    }
+                }
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -379,10 +392,11 @@ public class CopycatHalfLayerBlock extends WaterloggedMultiStateCopycatBlock imp
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(new FaceData(state.getValue(AXIS), state.getValue(HALF), state.getValue(property.equals(NEGATIVE_LAYERS.getName()) ? NEGATIVE_LAYERS : POSITIVE_LAYERS)), d -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, state.getValue(AXIS), state.getValue(HALF), state.getValue(property.equals(NEGATIVE_LAYERS.getName()) ? NEGATIVE_LAYERS : POSITIVE_LAYERS), face),
+                Shapes.empty()
+        ));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/slab/CopycatSlabBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/slab/CopycatSlabBlock.java
@@ -9,6 +9,7 @@ import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopyca
 import com.copycatsplus.copycats.foundation.copycat.model.ScaledBlockAndTintGetter;
 import com.copycatsplus.copycats.foundation.copycat.multistate.MaterialItemStorage;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.copycatsplus.copycats.utility.InteractionUtils;
 import com.mojang.math.OctahedralGroup;
 import com.simibubi.create.AllBlocks;
@@ -52,7 +53,9 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -64,6 +67,7 @@ public class CopycatSlabBlock extends WaterloggedMultiStateCopycatBlock implemen
 
     public static final EnumProperty<Axis> AXIS = BlockStateProperties.AXIS;
     public static final EnumProperty<SlabType> SLAB_TYPE = BlockStateProperties.SLAB_TYPE;
+    private final Map<String, Map<Axis, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
 
     private static final int placementHelperId = PlacementHelpers.register(new PlacementHelper());
 
@@ -242,6 +246,14 @@ public class CopycatSlabBlock extends WaterloggedMultiStateCopycatBlock implemen
         } else {
             return CCShapes.SLAB_TOP.get(axis).toShape();
         }
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(state.getValue(AXIS), d -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/slab/CopycatSlabBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/slab/CopycatSlabBlock.java
@@ -2,6 +2,7 @@ package com.copycatsplus.copycats.content.copycat.slab;
 
 import com.copycatsplus.copycats.CCBlocks;
 import com.copycatsplus.copycats.CCShapes;
+import com.copycatsplus.copycats.content.copycat.half_layer.CopycatHalfLayerBlock;
 import com.copycatsplus.copycats.foundation.copycat.CopycatTransformableState;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlock;
@@ -11,6 +12,7 @@ import com.copycatsplus.copycats.foundation.copycat.multistate.MaterialItemStora
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
 import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.copycatsplus.copycats.utility.InteractionUtils;
+import com.google.common.collect.ImmutableMap;
 import com.mojang.math.OctahedralGroup;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.contraptions.StructureTransform;
@@ -53,10 +55,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 
 import static com.copycatsplus.copycats.utility.BlockUtils.transformFacing;
@@ -67,7 +66,10 @@ public class CopycatSlabBlock extends WaterloggedMultiStateCopycatBlock implemen
 
     public static final EnumProperty<Axis> AXIS = BlockStateProperties.AXIS;
     public static final EnumProperty<SlabType> SLAB_TYPE = BlockStateProperties.SLAB_TYPE;
-    private final Map<String, Map<Axis, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
+
+    private static record FaceData(String property, Axis axis, Direction face) {
+    }
 
     private static final int placementHelperId = PlacementHelpers.register(new PlacementHelper());
 
@@ -76,6 +78,15 @@ public class CopycatSlabBlock extends WaterloggedMultiStateCopycatBlock implemen
         registerDefaultState(defaultBlockState()
                 .setValue(AXIS, Axis.Y)
                 .setValue(SLAB_TYPE, SlabType.BOTTOM));
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        for (String property : storageProperties()) {
+            for (Axis axis : AXIS.getPossibleValues()) {
+                for (Direction face : Direction.values()) {
+                    builder.put(new FaceData(property, axis, face), BlockFaceUtils.getPartialFaceShape(null, defaultBlockState().setValue(SLAB_TYPE, SlabType.DOUBLE).setValue(AXIS, axis), property, face));
+                }
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -250,10 +261,11 @@ public class CopycatSlabBlock extends WaterloggedMultiStateCopycatBlock implemen
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(state.getValue(AXIS), d -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, state.getValue(AXIS), face),
+                Shapes.empty()
+        ));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/stacked_half_layer/CopycatStackedHalfLayerBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/stacked_half_layer/CopycatStackedHalfLayerBlock.java
@@ -5,6 +5,7 @@ import com.copycatsplus.copycats.Copycats;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.content.contraptions.StructureTransform;
 import com.simibubi.create.content.schematics.requirement.ISpecialBlockItemRequirement;
@@ -37,9 +38,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import static com.copycatsplus.copycats.content.copycat.half_layer.CopycatHalfLayerBlock.*;
 
@@ -50,6 +49,7 @@ public class CopycatStackedHalfLayerBlock extends WaterloggedMultiStateCopycatBl
 
     public static final EnumProperty<Direction> FACING = BlockStateProperties.HORIZONTAL_FACING;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
+    private final Map<String, Map<Direction, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
 
     public CopycatStackedHalfLayerBlock(Properties pProperties) {
         super(pProperties);
@@ -228,6 +228,14 @@ public class CopycatStackedHalfLayerBlock extends WaterloggedMultiStateCopycatBl
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState pState, @NotNull BlockGetter pLevel, @NotNull BlockPos pPos, @NotNull CollisionContext pContext) {
         return Objects.requireNonNull(this.shapesCache.get(pState));
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(state.getValue(FACING), d -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/stacked_half_layer/CopycatStackedHalfLayerBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/stacked_half_layer/CopycatStackedHalfLayerBlock.java
@@ -2,6 +2,7 @@ package com.copycatsplus.copycats.content.copycat.stacked_half_layer;
 
 import com.copycatsplus.copycats.CCShapes;
 import com.copycatsplus.copycats.Copycats;
+import com.copycatsplus.copycats.content.copycat.half_layer.CopycatHalfLayerBlock;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
@@ -28,6 +29,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.Vec3;
@@ -39,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.copycatsplus.copycats.content.copycat.half_layer.CopycatHalfLayerBlock.*;
 
@@ -49,7 +52,10 @@ public class CopycatStackedHalfLayerBlock extends WaterloggedMultiStateCopycatBl
 
     public static final EnumProperty<Direction> FACING = BlockStateProperties.HORIZONTAL_FACING;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
-    private final Map<String, Map<Direction, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
+
+    private static record FaceData(String property, Direction facing, int layers, Direction face) {
+    }
 
     public CopycatStackedHalfLayerBlock(Properties pProperties) {
         super(pProperties);
@@ -59,6 +65,17 @@ public class CopycatStackedHalfLayerBlock extends WaterloggedMultiStateCopycatBl
                 .setValue(NEGATIVE_LAYERS, 0)
         );
         this.shapesCache = this.getShapeForEachState(CopycatStackedHalfLayerBlock::calculateMultiFaceShape);
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        for (String property : storageProperties()) {
+            for (Direction facing : FACING.getPossibleValues()) {
+                for (int layers : POSITIVE_LAYERS.getPossibleValues()) {
+                    for (Direction face : Direction.values()) {
+                        builder.put(new FaceData(property, facing, layers, face), BlockFaceUtils.getPartialFaceShape(null, defaultBlockState().setValue(FACING, facing).setValue(NEGATIVE_LAYERS, layers).setValue(POSITIVE_LAYERS, layers), property, face));
+                    }
+                }
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -232,10 +249,11 @@ public class CopycatStackedHalfLayerBlock extends WaterloggedMultiStateCopycatBl
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(state.getValue(FACING), d -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, state.getValue(FACING), state.getValue(property.equals(NEGATIVE_LAYERS.getName()) ? NEGATIVE_LAYERS : POSITIVE_LAYERS), face),
+                Shapes.empty()
+        ));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/vertical_half_layer/CopycatVerticalHalfLayerBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/vertical_half_layer/CopycatVerticalHalfLayerBlock.java
@@ -5,6 +5,7 @@ import com.copycatsplus.copycats.Copycats;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
+import com.copycatsplus.copycats.utility.BlockFaceUtils;
 import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.content.contraptions.StructureTransform;
 import com.simibubi.create.content.schematics.requirement.ISpecialBlockItemRequirement;
@@ -37,9 +38,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import static com.copycatsplus.copycats.content.copycat.half_layer.CopycatHalfLayerBlock.*;
 import static net.minecraft.core.Direction.Axis;
@@ -52,6 +51,7 @@ public class CopycatVerticalHalfLayerBlock extends WaterloggedMultiStateCopycatB
 
     public static final EnumProperty<Direction> FACING = BlockStateProperties.HORIZONTAL_FACING;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
+    private final Map<String, Map<Direction, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
 
     public CopycatVerticalHalfLayerBlock(Properties pProperties) {
         super(pProperties);
@@ -252,6 +252,14 @@ public class CopycatVerticalHalfLayerBlock extends WaterloggedMultiStateCopycatB
     @Override
     public @NotNull VoxelShape getShape(@NotNull BlockState pState, @NotNull BlockGetter pLevel, @NotNull BlockPos pPos, @NotNull CollisionContext pContext) {
         return Objects.requireNonNull(this.shapesCache.get(pState));
+    }
+
+    @Override
+    public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        return partialFaceCache
+                .computeIfAbsent(property, p -> new HashMap<>())
+                .computeIfAbsent(state.getValue(FACING), d -> new HashMap<>())
+                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/vertical_half_layer/CopycatVerticalHalfLayerBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/vertical_half_layer/CopycatVerticalHalfLayerBlock.java
@@ -2,6 +2,7 @@ package com.copycatsplus.copycats.content.copycat.vertical_half_layer;
 
 import com.copycatsplus.copycats.CCShapes;
 import com.copycatsplus.copycats.Copycats;
+import com.copycatsplus.copycats.content.copycat.stacked_half_layer.CopycatStackedHalfLayerBlock;
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
 import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.copycatsplus.copycats.foundation.copycat.multistate.WaterloggedMultiStateCopycatBlock;
@@ -51,7 +52,11 @@ public class CopycatVerticalHalfLayerBlock extends WaterloggedMultiStateCopycatB
 
     public static final EnumProperty<Direction> FACING = BlockStateProperties.HORIZONTAL_FACING;
     private final ImmutableMap<BlockState, VoxelShape> shapesCache;
-    private final Map<String, Map<Direction, Map<Direction, VoxelShape>>> partialFaceCache = new HashMap<>();
+    private final ImmutableMap<FaceData, VoxelShape> partialFaceCache;
+
+    private static record FaceData(String property, Direction facing, int layers, Direction face) {
+    }
+
 
     public CopycatVerticalHalfLayerBlock(Properties pProperties) {
         super(pProperties);
@@ -61,6 +66,17 @@ public class CopycatVerticalHalfLayerBlock extends WaterloggedMultiStateCopycatB
                 .setValue(NEGATIVE_LAYERS, 0)
         );
         this.shapesCache = this.getShapeForEachState(CopycatVerticalHalfLayerBlock::calculateMultiFaceShape);
+        ImmutableMap.Builder<FaceData, VoxelShape> builder = ImmutableMap.builder();
+        for (String property : storageProperties()) {
+            for (Direction facing : FACING.getPossibleValues()) {
+                for (int layers : POSITIVE_LAYERS.getPossibleValues()) {
+                    for (Direction face : Direction.values()) {
+                        builder.put(new FaceData(property, facing, layers, face), BlockFaceUtils.getPartialFaceShape(null, defaultBlockState().setValue(FACING, facing).setValue(NEGATIVE_LAYERS, layers).setValue(POSITIVE_LAYERS, layers), property, face));
+                    }
+                }
+            }
+        }
+        this.partialFaceCache = builder.build();
     }
 
     @Override
@@ -256,10 +272,11 @@ public class CopycatVerticalHalfLayerBlock extends WaterloggedMultiStateCopycatB
 
     @Override
     public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
-        return partialFaceCache
-                .computeIfAbsent(property, p -> new HashMap<>())
-                .computeIfAbsent(state.getValue(FACING), d -> new HashMap<>())
-                .computeIfAbsent(face, d -> BlockFaceUtils.getPartialFaceShape(level, state, property, face));
+        if (!partExists(state, property)) return Shapes.empty();
+        return Objects.requireNonNull(partialFaceCache.getOrDefault(
+                new FaceData(property, state.getValue(FACING), state.getValue(property.equals(NEGATIVE_LAYERS.getName()) ? NEGATIVE_LAYERS : POSITIVE_LAYERS), face),
+                Shapes.empty()
+        ));
     }
 
     public boolean supportsExternalFaceHiding(BlockState state) {

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlock.java
@@ -13,6 +13,7 @@ import com.copycatsplus.copycats.network.CCPackets;
 import com.copycatsplus.copycats.network.FillCopycatPacket;
 import com.copycatsplus.copycats.utility.BlockEntityUtils;
 import com.copycatsplus.copycats.utility.BlockFaceUtils;
+import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.AllTags;
@@ -43,11 +44,13 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 /**
@@ -412,6 +415,11 @@ public interface IMultiStateCopycatBlock extends ICopycatBlock, IStateType {
         BlockState material = IMultiStateCopycatBlock.getMaterial(reader, pos, property);
         return material.is(Blocks.AIR) ? AllBlocks.COPYCAT_BASE.getDefaultState() : material;
     }
+
+    /**
+     * Get the face shape of a particular part. Results of this method should be cached for performance.
+     */
+    VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face);
 
     static BlockState getMaterial(BlockGetter reader, BlockPos targetPos, String property) {
         if (reader.getBlockEntity(targetPos) instanceof IMultiStateCopycatBlockEntity cbe)

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlockEntity.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -130,6 +131,11 @@ public interface IMultiStateCopycatBlockEntity extends ICopycatBlockEntity {
             @Override
             public String getPropertyFromInteraction(BlockState state, BlockGetter level, Vec3i hitLocation, BlockPos blockPos, Direction facing, Vec3 unscaledHit) {
                 return defaultProperty();
+            }
+
+            @Override
+            public VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+                return state.getFaceOcclusionShape(level, BlockPos.ZERO, face);
             }
 
             @Override

--- a/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
+++ b/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
@@ -41,10 +41,11 @@ public class BlockFaceUtils {
             return cacheMap;
         });
         ShapeKey key = new ShapeKey(fromShape, toShape);
-        byte result = cache.getByte(key);
+        byte result = cache.getAndMoveToFirst(key);
         if (result == 127) {
             boolean value = operation.apply(fromShape, toShape);
-            cache.put(key, (byte) (value ? 1 : 0));
+            if (cache.size() >= 2048) cache.removeLastByte();
+            cache.putAndMoveToFirst(key, (byte) (value ? 1 : 0));
             return value;
         } else {
             return result == 1;

--- a/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
+++ b/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
@@ -177,9 +177,6 @@ public class BlockFaceUtils {
 
     public static VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
         IMultiStateCopycatBlock copycatBlock = (IMultiStateCopycatBlock) state.getBlock();
-        if (!copycatBlock.partExists(state, property)) {
-            return Shapes.empty();
-        }
         Vec3i scale = copycatBlock.vectorScale(state);
         Vec3i part = copycatBlock.getVectorFromProperty(state, property);
         return getPartialFaceShape(state.getOcclusionShape(level, BlockPos.ZERO), face, part, scale);

--- a/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
+++ b/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
@@ -65,15 +65,7 @@ public class BlockFaceUtils {
                 if (!copycatBlock.partExists(fromState, property))
                     return false;
                 inner = copycatBlock.getVectorFromProperty(fromState, property);
-                fromShape = getPartialFaceShape(fromState.getOcclusionShape(scaledWorld.getWrapped(), truePos),
-                        fromFace,
-                        inner.getX() / (double) scale.getX(),
-                        inner.getY() / (double) scale.getY(),
-                        inner.getZ() / (double) scale.getZ(),
-                        1.0 / scale.getX(),
-                        1.0 / scale.getY(),
-                        1.0 / scale.getZ()
-                );
+                fromShape = copycatBlock.getPartialFaceShape(scaledWorld, fromState, property, fromFace);
             }
         }
         if (fromShape == null) {
@@ -84,46 +76,52 @@ public class BlockFaceUtils {
         }
 
         VoxelShape toShape = null;
-        List<Vec3i> potentialParts = null;
+        List<String> potentialParts = null;
         if (toState.getBlock() instanceof IMultiStateCopycatBlock copycatBlock) {
             Vec3i toScale = copycatBlock.vectorScale(toState);
             Axis connectingAxis = fromFace.getAxis();
             BlockGetter world = level;
             BlockPos toTruePos = toPos;
+            String fallbackProperty = copycatBlock.defaultProperty();
             if (level instanceof ScaledBlockAndTintGetter scaledWorld) {
                 world = scaledWorld.getWrapped();
                 toTruePos = scaledWorld.getTruePos(toPos);
+                fallbackProperty = scaledWorld.getRenderingProperty();
                 if (toTruePos.equals(truePos)) {
-                    String toProperty = scaledWorld.getPropertyForRender(toState, toPos);
-                    potentialParts = List.of(copycatBlock.getVectorFromProperty(toState, toProperty));
+                    potentialParts = List.of(scaledWorld.getPropertyForRender(toState, toPos));
                 }
             }
             if (potentialParts == null) {
                 if (replaceAxis(scale, connectingAxis, 0).equals(replaceAxis(toScale, connectingAxis, 0))) {
-                    potentialParts = List.of(replaceAxis(inner, connectingAxis,
+                    potentialParts = List.of(copycatBlock.getPropertyFromRender(fallbackProperty, toState, world, replaceAxis(inner, connectingAxis,
                             fromFace.getAxisDirection() == Direction.AxisDirection.POSITIVE ? 0 : (toScale.get(connectingAxis) - 1)
-                    ));
+                    ), toTruePos));
                 } else {
-                    potentialParts = getOverlappingParts(toScale, connectingAxis,
-                            fromFace.getAxisDirection() == Direction.AxisDirection.POSITIVE ? 0 : (toScale.get(connectingAxis) - 1)
-                    );
+                    potentialParts = new ArrayList<>(4);
+                    int connectingPart = fromFace.getAxisDirection() == Direction.AxisDirection.POSITIVE ? 0 : (toScale.get(connectingAxis) - 1);
+                    Axis axis1 = switch (connectingAxis) {
+                        case X -> Axis.Y;
+                        case Y -> Axis.Z;
+                        case Z -> Axis.X;
+                    };
+                    Axis axis2 = switch (connectingAxis) {
+                        case X -> Axis.Z;
+                        case Y -> Axis.X;
+                        case Z -> Axis.Y;
+                    };
+                    for (int i = 0; i < toScale.get(axis1); i++) {
+                        for (int j = 0; j < toScale.get(axis2); j++) {
+                            potentialParts.add(copycatBlock.getPropertyFromRender(fallbackProperty, toState, world, replaceAxis(replaceAxis(new Vec3i(connectingPart, connectingPart, connectingPart), axis1, i), axis2, j), toTruePos));
+                        }
+                    }
                 }
             }
-            VoxelShape baseShape = toState.getOcclusionShape(world, toTruePos);
-            for (Vec3i part : potentialParts) {
-                toShape = getPartialFaceShape(baseShape,
-                        fromFace.getOpposite(),
-                        part.getX() / (double) toScale.getX(),
-                        part.getY() / (double) toScale.getY(),
-                        part.getZ() / (double) toScale.getZ(),
-                        1.0 / toScale.getX(),
-                        1.0 / toScale.getY(),
-                        1.0 / toScale.getZ()
-                );
+            for (String partProp : potentialParts) {
+                toShape = copycatBlock.getPartialFaceShape(world, toState, partProp, fromFace.getOpposite());
                 if (operation.apply(fromShape, toShape)) {
                     String property = CopycatExternalContext.getPropertyForAppearance();
                     if (property == null) property = copycatBlock.defaultProperty();
-                    CopycatExternalContext.setPropertyForAppearance(copycatBlock.getPropertyFromRender(property, toState, world, part, toTruePos));
+                    CopycatExternalContext.setPropertyForAppearance(copycatBlock.getPropertyFromRender(property, toState, world, copycatBlock.getVectorFromProperty(toState, partProp), toTruePos));
                     return true;
                 }
             }
@@ -173,9 +171,25 @@ public class BlockFaceUtils {
                 MATCH_CACHE.get());
     }
 
-    public static VoxelShape getPartialFaceShape(VoxelShape voxelShape, Direction direction, double startX, double startY, double startZ, double sizeX, double sizeY, double sizeZ) {
+    public static VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {
+        IMultiStateCopycatBlock copycatBlock = (IMultiStateCopycatBlock) state.getBlock();
+        if (!copycatBlock.partExists(state, property)) {
+            return Shapes.empty();
+        }
+        Vec3i scale = copycatBlock.vectorScale(state);
+        Vec3i part = copycatBlock.getVectorFromProperty(state, property);
+        return getPartialFaceShape(state.getOcclusionShape(level, BlockPos.ZERO), face, part, scale);
+    }
+
+    public static VoxelShape getPartialFaceShape(VoxelShape voxelShape, Direction direction, Vec3i part, Vec3i scale) {
         int i;
         Axis axis = direction.getAxis();
+        double startX = part.getX() / (double) scale.getX();
+        double startY = part.getY() / (double) scale.getY();
+        double startZ = part.getZ() / (double) scale.getZ();
+        double sizeX = 1.0 / scale.getX();
+        double sizeY = 1.0 / scale.getY();
+        double sizeZ = 1.0 / scale.getZ();
         double endX = startX + sizeX;
         double endY = startY + sizeY;
         double endZ = startZ + sizeZ;
@@ -202,25 +216,5 @@ public class BlockFaceUtils {
             return Shapes.empty();
         }
         return new SliceShape(voxelShape, axis, i);
-    }
-
-    private static List<Vec3i> getOverlappingParts(Vec3i toScale, Axis connectingAxis, int connectingPart) {
-        Axis axis1 = switch (connectingAxis) {
-            case X -> Axis.Y;
-            case Y -> Axis.Z;
-            case Z -> Axis.X;
-        };
-        Axis axis2 = switch (connectingAxis) {
-            case X -> Axis.Z;
-            case Y -> Axis.X;
-            case Z -> Axis.Y;
-        };
-        List<Vec3i> parts = new ArrayList<>(4);
-        for (int i = 0; i < toScale.get(axis1); i++) {
-            for (int j = 0; j < toScale.get(axis2); j++) {
-                parts.add(replaceAxis(replaceAxis(new Vec3i(connectingPart, connectingPart, connectingPart), axis1, i), axis2, j));
-            }
-        }
-        return parts;
     }
 }

--- a/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
+++ b/common/src/main/java/com/copycatsplus/copycats/utility/BlockFaceUtils.java
@@ -12,37 +12,44 @@ import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Vec3i;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.*;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 
 import static com.copycatsplus.copycats.utility.MathUtils.*;
 
 public class BlockFaceUtils {
-    private static final ThreadLocal<Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey>> OCCLUSION_CACHE = ThreadLocal.withInitial(() -> {
-        Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey> cacheMap = new Object2ByteLinkedOpenHashMap<>(2048, 0.25f) {
 
-            @Override
-            protected void rehash(int i) {
-            }
-        };
-        cacheMap.defaultReturnValue((byte) 127);
-        return cacheMap;
-    });
-    private static final ThreadLocal<Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey>> MATCH_CACHE = ThreadLocal.withInitial(() -> {
-        Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey> cacheMap = new Object2ByteLinkedOpenHashMap<>(2048, 0.25f) {
+    private static final ThreadLocal<Map<BiFunction<VoxelShape, VoxelShape, Boolean>, Object2ByteLinkedOpenHashMap<ShapeKey>>> SHAPE_OP_CACHE = ThreadLocal.withInitial(HashMap::new);
 
-            @Override
-            protected void rehash(int i) {
-            }
-        };
-        cacheMap.defaultReturnValue((byte) 127);
-        return cacheMap;
-    });
+    public static record ShapeKey(VoxelShape fromShape, VoxelShape toShape) {
+    }
+
+    private static boolean invokeCachedOperation(BiFunction<VoxelShape, VoxelShape, Boolean> operation, VoxelShape fromShape, VoxelShape toShape) {
+        Object2ByteLinkedOpenHashMap<ShapeKey> cache = SHAPE_OP_CACHE.get().computeIfAbsent(operation, op -> {
+            Object2ByteLinkedOpenHashMap<ShapeKey> cacheMap = new Object2ByteLinkedOpenHashMap<>(2048, 0.25f) {
+                @Override
+                protected void rehash(int i) {
+                }
+            };
+            cacheMap.defaultReturnValue((byte) 127);
+            return cacheMap;
+        });
+        ShapeKey key = new ShapeKey(fromShape, toShape);
+        byte result = cache.getByte(key);
+        if (result == 127) {
+            boolean value = operation.apply(fromShape, toShape);
+            cache.put(key, (byte) (value ? 1 : 0));
+            return value;
+        } else {
+            return result == 1;
+        }
+    }
 
     private static boolean processBlockFace(BlockGetter level,
                                             BlockState fromState,
@@ -50,8 +57,7 @@ public class BlockFaceUtils {
                                             BlockState toState,
                                             BlockPos toPos,
                                             Direction fromFace,
-                                            BiFunction<VoxelShape, VoxelShape, Boolean> operation,
-                                            Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey> cache) {
+                                            BiFunction<VoxelShape, VoxelShape, Boolean> operation) {
         VoxelShape fromShape = null;
         Vec3i scale = new Vec3i(1, 1, 1);
         Vec3i inner = new Vec3i(0, 0, 0);
@@ -118,7 +124,7 @@ public class BlockFaceUtils {
             }
             for (String partProp : potentialParts) {
                 toShape = copycatBlock.getPartialFaceShape(world, toState, partProp, fromFace.getOpposite());
-                if (operation.apply(fromShape, toShape)) {
+                if (invokeCachedOperation(operation, fromShape, toShape)) {
                     String property = CopycatExternalContext.getPropertyForAppearance();
                     if (property == null) property = copycatBlock.defaultProperty();
                     CopycatExternalContext.setPropertyForAppearance(copycatBlock.getPropertyFromRender(property, toState, world, copycatBlock.getVectorFromProperty(toState, partProp), toTruePos));
@@ -130,7 +136,7 @@ public class BlockFaceUtils {
             toShape = toState.getFaceOcclusionShape(level, toPos, fromFace.getOpposite());
         }
         CopycatExternalContext.setPropertyForAppearance(null);
-        return operation.apply(fromShape, toShape);
+        return invokeCachedOperation(operation, fromShape, toShape);
     }
 
     /**
@@ -148,8 +154,7 @@ public class BlockFaceUtils {
                 occludingState,
                 occludingPos,
                 occludedFace,
-                (occluded, occluding) -> !Shapes.joinIsNotEmpty(occluded, occluding, BooleanOp.ONLY_FIRST),
-                OCCLUSION_CACHE.get());
+                (occluded, occluding) -> !Shapes.joinIsNotEmpty(occluded, occluding, BooleanOp.ONLY_FIRST));
     }
 
     /**
@@ -167,8 +172,7 @@ public class BlockFaceUtils {
                 toState,
                 toPos,
                 fromFace,
-                (from, to) -> !Shapes.joinIsNotEmpty(from, to, BooleanOp.NOT_SAME),
-                MATCH_CACHE.get());
+                (from, to) -> !Shapes.joinIsNotEmpty(from, to, BooleanOp.NOT_SAME));
     }
 
     public static VoxelShape getPartialFaceShape(BlockGetter level, BlockState state, String property, Direction face) {


### PR DESCRIPTION
Rough benchmarks:

Before: https://spark.lucko.me/eNjaslbPgi (3416ms for 10 train assemblies)

After: https://spark.lucko.me/0YFUQFbAqL (1500ms for 10 train assemblies)