### PR TITLE
Fix missing InteractionUtilsImpl on fabric

### DIFF
--- a/fabric/src/main/java/com/copycatsplus/copycats/utility/fabric/InteractionUtilsImpl.java
+++ b/fabric/src/main/java/com/copycatsplus/copycats/utility/fabric/InteractionUtilsImpl.java
@@ -1,0 +1,12 @@
+package com.copycatsplus.copycats.utility.fabric;
+
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.player.Player;
+
+public class InteractionUtilsImpl {
+
+    public static AttributeInstance getPlayerReach(Player player) {
+       return player.getAttribute(ReachEntityAttributes.REACH);
+    }
+}


### PR DESCRIPTION
This PR implements `InteractionUtils` on Fabric, preventing a crash when placement assist on Copycats+-specific copycats is rendered.