### PR TITLE
Fix copycat vertical stairs recipe

### DIFF
--- a/common/src/main/java/com/copycatsplus/copycats/datagen/recipes/CCStandardRecipes.java
+++ b/common/src/main/java/com/copycatsplus/copycats/datagen/recipes/CCStandardRecipes.java
@@ -184,21 +184,7 @@ public class CCStandardRecipes extends CopycatsRecipeProvider {
 
     GeneratedRecipe COPYCAT_VERTICAL_STAIRS = copycat(CCBlocks.COPYCAT_VERTICAL_STAIRS, 1);
 
-    GeneratedRecipe COPYCAT_STAIRS_CYCLE_1 = create(CCBlocks.COPYCAT_STAIRS).withSuffix("_from_conversion")
-            .unlockedBy(CCBlocks.COPYCAT_VERTICAL_STAIRS::get)
-            .requiresResultFeature()
-            .requiresFeature(CCBlocks.COPYCAT_VERTICAL_STAIRS)
-            .viaShapeless(b -> b
-                    .requires(CCBlocks.COPYCAT_VERTICAL_STAIRS)
-            );
-
-    GeneratedRecipe COPYCAT_STAIRS_CYCLE_2 = create(CCBlocks.COPYCAT_VERTICAL_STAIRS).withSuffix("_from_conversion")
-            .unlockedByTag(() -> CCTags.Items.COPYCAT_STAIRS.tag)
-            .requiresResultFeature()
-            .requiresFeature(CCBlocks.COPYCAT_STAIRS)
-            .viaShapeless(b -> b
-                    .requires(CCTags.Items.COPYCAT_STAIRS.tag)
-            );
+    GeneratedRecipe COPYCAT_STAIRS_CYCLE = conversionCycle(CCBlocks.COPYCAT_STAIRS, CCBlocks.COPYCAT_VERTICAL_STAIRS);
 
     GeneratedRecipe COPYCAT_GHOST_BLOCK = copycat(CCBlocks.COPYCAT_GHOST_BLOCK, 1);
 

--- a/neoforge/src/generated/resources/data/copycats/advancement/recipes/misc/crafting/copycat_stairs_from_conversion.json
+++ b/neoforge/src/generated/resources/data/copycats/advancement/recipes/misc/crafting/copycat_stairs_from_conversion.json
@@ -2,12 +2,12 @@
   "neoforge:conditions": [
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_stairs",
+      "feature": "copycats:copycat_vertical_stairs",
       "invert": false
     },
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_vertical_stairs",
+      "feature": "copycats:copycat_stairs",
       "invert": false
     }
   ],

--- a/neoforge/src/generated/resources/data/copycats/advancement/recipes/misc/crafting/copycat_vertical_stairs_from_conversion.json
+++ b/neoforge/src/generated/resources/data/copycats/advancement/recipes/misc/crafting/copycat_vertical_stairs_from_conversion.json
@@ -2,12 +2,12 @@
   "neoforge:conditions": [
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_vertical_stairs",
+      "feature": "copycats:copycat_stairs",
       "invert": false
     },
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_stairs",
+      "feature": "copycats:copycat_vertical_stairs",
       "invert": false
     }
   ],
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "items": "#copycats:copycat_stairs"
+            "items": "copycats:copycat_stairs"
           }
         ]
       },

--- a/neoforge/src/generated/resources/data/copycats/recipe/crafting/copycat_stairs_from_conversion.json
+++ b/neoforge/src/generated/resources/data/copycats/recipe/crafting/copycat_stairs_from_conversion.json
@@ -2,12 +2,12 @@
   "neoforge:conditions": [
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_stairs",
+      "feature": "copycats:copycat_vertical_stairs",
       "invert": false
     },
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_vertical_stairs",
+      "feature": "copycats:copycat_stairs",
       "invert": false
     }
   ],

--- a/neoforge/src/generated/resources/data/copycats/recipe/crafting/copycat_vertical_stairs_from_conversion.json
+++ b/neoforge/src/generated/resources/data/copycats/recipe/crafting/copycat_vertical_stairs_from_conversion.json
@@ -2,12 +2,12 @@
   "neoforge:conditions": [
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_vertical_stairs",
+      "feature": "copycats:copycat_stairs",
       "invert": false
     },
     {
       "type": "copycats:feature_enabled",
-      "feature": "copycats:copycat_stairs",
+      "feature": "copycats:copycat_vertical_stairs",
       "invert": false
     }
   ],
@@ -15,7 +15,7 @@
   "category": "misc",
   "ingredients": [
     {
-      "tag": "copycats:copycat_stairs"
+      "item": "copycats:copycat_stairs"
     }
   ],
   "result": {


### PR DESCRIPTION
<img width="1436" height="1306" alt="Untitled-1-Recovered" src="https://github.com/user-attachments/assets/b8960cba-2d77-4e17-8ac3-43bafa63471a" />
Previously, the copycat vertical stairs from conversion recipe had a tag match for copycat_stairs instead of item match. This created a cc vertical stairs -> cc vertical stairs crafting route that blocks the cc vertical stairs -> cc stairs craft. Presumably, this is by mistake. Fixing this recipe produces a more reasonable behavior.