### PR TITLE
Add Compatibility with Sable Physics Mod

### DIFF
--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_beam.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_beam.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_beam",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_board.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_board.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_board",
+
+  "properties": {
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_box.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_box.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_box",
+
+  "properties": {
+    "sable:mass": 1,
+    "sable:volume": 1
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_box.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_box.json
@@ -1,8 +1,0 @@
-{
-  "selector": "copycats:copycat_box",
-
-  "properties": {
-    "sable:mass": 1,
-    "sable:volume": 1
-  }
-}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_byte.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_byte.json
@@ -1,0 +1,18 @@
+{
+  "selector": "copycats:copycat_byte",
+
+  "properties": {
+    "sable:mass": 0.125,
+    "sable:volume": 0.125
+  },
+
+  "overrides": {
+    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_byte_panel.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_byte_panel.json
@@ -1,5 +1,5 @@
 {
-  "selector": "copycats:copycat_byte",
+  "selector": "copycats:copycat_byte_panel",
 
   "properties": {
     "sable:mass": 0.25,

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_byte_panel.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_byte_panel.json
@@ -2,7 +2,7 @@
   "selector": "copycats:copycat_byte",
 
   "properties": {
-    "sable:mass": 0.5,
-    "sable:volume": 0.5
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
   }
 }

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_catwalk.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_catwalk.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_catwalk",
+
+  "properties": {
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_cogwheel.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_cogwheel.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_cogwheel",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_corner_slice.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_corner_slice.json
@@ -1,0 +1,18 @@
+{
+  "selector": "copycats:copycat_corner_slice",
+
+  "properties": {
+    "sable:mass": 0.125,
+    "sable:volume": 0.125
+  },
+
+  "overrides": {
+    "layers=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "layers=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "layers=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "layers=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "layers=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "layers=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "layers=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_flat_pane.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_flat_pane.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_flat_pane",
+
+  "properties": {
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_half_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_half_layer.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_half_layer",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_half_panel.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_half_panel.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_half_panel",
+
+  "properties": {
+    "sable:mass": 0.0,
+    "sable:volume": 0.0
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_ladder.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_ladder.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_ladder",
+
+  "properties": {
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_large_cogwheel.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_large_cogwheel.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_large_cogwheel",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_layer.json
@@ -1,0 +1,18 @@
+{
+  "selector": "copycats:copycat_layer",
+
+  "properties": {
+    "sable:mass": 0.125,
+    "sable:volume": 0.125
+  },
+
+  "overrides": {
+    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_layer.json
@@ -7,12 +7,12 @@
   },
 
   "overrides": {
-    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
-    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
-    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
-    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
-    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
-    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
-    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+    "layers=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "layers=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "layers=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "layers=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "layers=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "layers=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "layers=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
   }
 }

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_pane.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_pane.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_pane",
+
+  "properties": {
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_shaft.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_shaft.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_shaft",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_slice.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_slice.json
@@ -1,0 +1,18 @@
+{
+  "selector": "copycats:copycat_slice",
+
+  "properties": {
+    "sable:mass": 0.125,
+    "sable:volume": 0.125
+  },
+
+  "overrides": {
+    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_slice.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_slice.json
@@ -7,12 +7,12 @@
   },
 
   "overrides": {
-    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
-    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
-    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
-    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
-    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
-    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
-    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+    "layers=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "layers=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "layers=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "layers=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "layers=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "layers=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "layers=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
   }
 }

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_slope.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_slope.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_slope",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_slope_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_slope_layer.json
@@ -1,0 +1,18 @@
+{
+  "selector": "copycats:copycat_slope_layer",
+
+  "properties": {
+    "sable:mass": 0.125,
+    "sable:volume": 0.125
+  },
+
+  "overrides": {
+    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_slope_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_slope_layer.json
@@ -7,12 +7,12 @@
   },
 
   "overrides": {
-    "count=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
-    "count=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
-    "count=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
-    "count=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
-    "count=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
-    "count=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
-    "count=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+    "layers=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "layers=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "layers=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "layers=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "layers=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "layers=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "layers=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
   }
 }

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_stacked_half_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_stacked_half_layer.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_stacked_half_layer",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_half_layer.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_half_layer.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_vertical_half_layer",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_slice.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_slice.json
@@ -1,0 +1,18 @@
+{
+  "selector": "copycats:copycat_vertical_slice",
+
+  "properties": {
+    "sable:mass": 0.125,
+    "sable:volume": 0.125
+  },
+
+  "overrides": {
+    "layers=2": { "sable:mass": 0.25,  "sable:volume": 0.25  },
+    "layers=3": { "sable:mass": 0.375, "sable:volume": 0.375 },
+    "layers=4": { "sable:mass": 0.5,   "sable:volume": 0.5   },
+    "layers=5": { "sable:mass": 0.625, "sable:volume": 0.625 },
+    "layers=6": { "sable:mass": 0.75,  "sable:volume": 0.75  },
+    "layers=7": { "sable:mass": 0.875, "sable:volume": 0.875 },
+    "layers=8": { "sable:mass": 1.0,   "sable:volume": 1.0   }
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_slope.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_slope.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_vertical_slope",
+
+  "properties": {
+    "sable:mass": 0.5,
+    "sable:volume": 0.5
+  }
+}

--- a/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_step.json
+++ b/common/src/main/resources/data/copycats/physics_block_properties/copycat_vertical_step.json
@@ -1,0 +1,8 @@
+{
+  "selector": "copycats:copycat_vertical_step",
+
+  "properties": {
+    "sable:mass": 0.25,
+    "sable:volume": 0.25
+  }
+}


### PR DESCRIPTION
Previously, most non-vanilla based Copycat blocks had the default weight of 1kpg, which makes building detailed simulated contraptions challenging. This gives all the non-cube Copycat blocks a lower weight. The blocks with a 'layers' count will have their weight increase as expected, however Half Layers, Bytes, and Byte Panels do not have this feature.