### PR TITLE
Fix Tags for Copycat Iron Door, Trapdoor, and Iron Trapdoor NeoForge

### DIFF
--- a/common/src/main/java/com/copycatsplus/copycats/CCBlocks.java
+++ b/common/src/main/java/com/copycatsplus/copycats/CCBlocks.java
@@ -558,6 +558,8 @@ public class CCBlocks {
                             CopycatCharacteristics.COPYCAT,
                             CopycatCharacteristics.FUNCTIONAL
                     ))
+                    .tag(ItemTags.TRAPDOORS)
+                    .tag(ItemTags.WOODEN_TRAPDOORS)
                     .transform(customItemModel("copycat_base", "trapdoor"))
                     .register();
 
@@ -573,6 +575,7 @@ public class CCBlocks {
                             CopycatCharacteristics.COPYCAT,
                             CopycatCharacteristics.FUNCTIONAL
                     ))
+                    .tag(ItemTags.TRAPDOORS)
                     .transform(customItemModel("copycat_base", "trapdoor"))
                     .register();
 
@@ -733,6 +736,8 @@ public class CCBlocks {
                     .transform(FeatureToggle.register(FeatureCategory.FUNCTIONAL))
                     .onRegister(interactionBehaviour(new DoorMovingInteraction()))
                     .onRegister(onClient(() -> createBlockModel(CopycatDoorModelCore::new)))
+                    .tag(BlockTags.DOORS)
+                    .tag(BlockTags.WOODEN_DOORS) // for villager AI
                     .onRegister(b -> registerBrittleCheck(state -> state.getBlock() == b ? CheckResult.SUCCESS : CheckResult.PASS))
                     .loot((lr, block) -> lr.add(block, lr.createDoorTable(block)))
                     .item()
@@ -753,6 +758,7 @@ public class CCBlocks {
                     .onRegister(onClient(() -> createBlockModel(CopycatDoorModelCore::new)))
                     .onRegister(interactionBehaviour(new DoorMovingInteraction()))
                     .onRegister(b -> registerBrittleCheck(state -> state.getBlock() == b ? CheckResult.SUCCESS : CheckResult.PASS))
+                    .tag(BlockTags.DOORS)
                     .loot((lr, block) -> lr.add(block, lr.createDoorTable(block)))
                     .item()
                     .onRegister(CopycatDescription.register(
@@ -760,6 +766,8 @@ public class CCBlocks {
                             CopycatCharacteristics.CT_TOGGLE,
                             CopycatCharacteristics.FUNCTIONAL
                     ))
+                    .tag(ItemTags.DOORS)
+                    .tag(AllTags.AllItemTags.CONTRAPTION_CONTROLLED.tag)
                     .transform(customItemModel("copycat_base", "door"))
                     .register();
 

--- a/neoforge/src/generated/resources/data/create/tags/item/contraption_controlled.json
+++ b/neoforge/src/generated/resources/data/create/tags/item/contraption_controlled.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "copycats:copycat_door",
+    "copycats:copycat_iron_door",
     "copycats:copycat_sliding_door",
     "copycats:copycat_folding_door"
   ]

--- a/neoforge/src/generated/resources/data/minecraft/tags/block/doors.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/block/doors.json
@@ -1,5 +1,7 @@
 {
   "values": [
+    "copycats:copycat_door",
+    "copycats:copycat_iron_door",
     "copycats:copycat_sliding_door",
     "copycats:copycat_folding_door"
   ]

--- a/neoforge/src/generated/resources/data/minecraft/tags/block/wooden_doors.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/block/wooden_doors.json
@@ -1,5 +1,6 @@
 {
   "values": [
+    "copycats:copycat_door",
     "copycats:copycat_sliding_door",
     "copycats:copycat_folding_door"
   ]

--- a/neoforge/src/generated/resources/data/minecraft/tags/item/doors.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/item/doors.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "copycats:copycat_door",
+    "copycats:copycat_iron_door",
     "copycats:copycat_sliding_door",
     "copycats:copycat_folding_door"
   ]

--- a/neoforge/src/generated/resources/data/minecraft/tags/item/trapdoors.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/item/trapdoors.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "copycats:copycat_trapdoor",
+    "copycats:copycat_iron_trapdoor"
+  ]
+}

--- a/neoforge/src/generated/resources/data/minecraft/tags/item/wooden_trapdoors.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/item/wooden_trapdoors.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "copycats:copycat_trapdoor"
+  ]
+}


### PR DESCRIPTION
The Copycat Iron Door, Trapdoor, and Iron Trapdoor were missing some block and/or item tags so I added them in. The missing tags have caused issues, seen in #377 . This should also improve compatibility with other data-driven mods.
As far as I'm aware there is no stated reason on why these tags were not included previously.
