### PR TITLE
Resolve client crash while building chunk meshes

### DIFF
--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/bytes/CopycatByteBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/bytes/CopycatByteBlock.java
@@ -151,6 +151,10 @@ public class CopycatByteBlock extends WaterloggedMultiStateCopycatBlock implemen
     @Override
     public Vec3i getVectorFromProperty(BlockState state, String property) {
         Byte bite = byteMap.get(property);
+        if(bite == null)
+        {
+            return new Vec3i(0,0,0);
+        }
         return new Vec3i(bite.x ? 1 : 0, bite.y ? 1 : 0, bite.z ? 1 : 0);
     }
 


### PR DESCRIPTION
Copycats was encountering a null pointer exception here while the client was trying to build chunks in Neoforge 21.1.228. See https://github.com/copycats-plus/copycats/issues/371

Further testing is still needed to see if a different crash also occurs once this fix is in place.