### PR TITLE
Fix #238: Fall Particles on Neoforge now correctly use the block material.

### DIFF
--- a/neoforge/src/main/java/com/copycatsplus/copycats/neoforge/mixin/foundation/copycat/CopycatBlockMixin.java
+++ b/neoforge/src/main/java/com/copycatsplus/copycats/neoforge/mixin/foundation/copycat/CopycatBlockMixin.java
@@ -1,5 +1,6 @@
 package com.copycatsplus.copycats.neoforge.mixin.foundation.copycat;
 
+import com.copycatsplus.copycats.Copycats;
 import com.copycatsplus.copycats.content.copycat.button.CopycatButtonBlock;
 import com.copycatsplus.copycats.content.copycat.door.CopycatDoorBlock;
 import com.copycatsplus.copycats.content.copycat.fence.CopycatFenceBlock;
@@ -21,6 +22,8 @@ import com.copycatsplus.copycats.foundation.copycat.model.neoforge.CopycatModelN
 import com.simibubi.create.AllBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.particles.BlockParticleOption;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -118,11 +121,22 @@ public abstract class CopycatBlockMixin extends Block implements ICopycatBlock {
     @Override
     public boolean addLandingEffects(BlockState state1, ServerLevel level, BlockPos pos, BlockState state2,
                                      LivingEntity entity, int numberOfParticles) {
-        return getMaterial(level, pos).addLandingEffects(level, pos, state2, entity, numberOfParticles);
+        BlockState material = getMaterial(level, pos);
+
+        // addLandingEffect is true if a *custom* fall block particle is defined
+        // for the material.
+        if (material.addLandingEffects(level, pos, state2, entity, numberOfParticles))
+            return true;
+
+        // As there isn't a custom effect, this copies how vanilla makes the particles,
+        // but as a custom landing effect. See LivingEntity#checkFallDamage
+        level.sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, material).setPos(pos), entity.getX(), entity.getY(), entity.getZ(), numberOfParticles, 0.0f, 0.0f, 0.0f, 0.15f);
+        return true;
     }
 
     @Override
     public boolean addRunningEffects(BlockState state, Level level, BlockPos pos, Entity entity) {
+        Copycats.LOGGER.info("Running !!");
         return getMaterial(level, pos).addRunningEffects(level, pos, entity);
     }
 

--- a/neoforge/src/main/java/com/copycatsplus/copycats/neoforge/mixin/foundation/copycat/multistate/MultiStateCopycatBlockMixin.java
+++ b/neoforge/src/main/java/com/copycatsplus/copycats/neoforge/mixin/foundation/copycat/multistate/MultiStateCopycatBlockMixin.java
@@ -10,6 +10,8 @@ import com.copycatsplus.copycats.content.copycat.cogwheel.CopycatCogWheelBlock;
 import com.simibubi.create.AllBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.particles.BlockParticleOption;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -33,6 +35,8 @@ import org.spongepowered.asm.mixin.Unique;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static com.copycatsplus.copycats.foundation.copycat.ICopycatBlock.getMaterial;
 
 /**
  * Implement platform-specific methods for multi-state copycat blocks.
@@ -135,8 +139,15 @@ public abstract class MultiStateCopycatBlockMixin extends Block implements IBloc
             IMultiStateCopycatBlockEntity copycatBE = copycatBlock.getCopycatBlockEntity(level, pos);
             if (copycatBE == null)
                 return super.addLandingEffects(state1, level, pos, state2, entity, numberOfParticles);
+
             BlockState material = copycatBE.getMaterialItemStorage().getMaterialItem(property).material();
-            return material.addLandingEffects(level, pos, material, entity, numberOfParticles);
+
+            // See CopycatBlockMixin#addLandingEffects for explanation
+            if (material.addLandingEffects(level, pos, material, entity, numberOfParticles))
+                return true;
+
+            level.sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, material).setPos(pos), entity.getX(), entity.getY(), entity.getZ(), numberOfParticles, 0.0f, 0.0f, 0.0f, 0.15f);
+            return true;
         } else {
             return super.addLandingEffects(state1, level, pos, state2, entity, numberOfParticles);
         }


### PR DESCRIPTION
Fixes #238, #373  - from what I understand, `addLandingEffect` under NeoForge is used for creating custom fall particles for blocks outside of what is defined inside of block models. This method is optional, though, so any block without non-model particles would fall back to vanilla particles, which would use the missing texture.

I looked at fabric 1.20.1 too and that seems to be fine.