### PR TITLE
Add incompatibility for aero copycats <=1.1.1

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -36,5 +36,8 @@
     "fabricloader": ">=0.15.7",
     "minecraft": ">=1.20.1",
     "create": "${create_fabric_range}"
+  },
+  "breaks": {
+    "aerocopycats": "<=1.1.1"
   }
 }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -31,6 +31,11 @@ issueTrackerURL="${mod_issues}"
    versionRange="${create_neoforge_range}"
    ordering="NONE"
    side="BOTH"
+[[dependencies.${archives_base_name}]]
+   modId="aerocopycats"
+   type="incompatible"
+   reason="Causes copycats to crash on assembly"
+   versionRange="(,1.1.1]"
 
 [[mixins]]
 config = "copycats-common.mixins.json"


### PR DESCRIPTION
Aero copycats adds physics block properties for copycats+ blocks, but that was already implemented in https://github.com/copycats-plus/copycats/pull/382. It also makes all copycat blocks function as wings, but doesn't properly add mixins for each block causing crashes on assembly https://github.com/ryanhcode/sable/issues/869.

The mod is closed-source and ARR, so it's not possible to make a PR to the mod and fix the issue. The developer hasn't updated the mod on modrinth in ~2 months, so it's not likely they will fix this issue.

This change makes all current aero copycats jars incompatible to hopefully prevent users from installing both mods together by mistake.