### PR TITLE
Implement light capabilities in copycats, add redstone lamp

### DIFF
--- a/common/src/main/java/com/copycatsplus/copycats/CCBlockEntityTypes.java
+++ b/common/src/main/java/com/copycatsplus/copycats/CCBlockEntityTypes.java
@@ -33,6 +33,7 @@ public class CCBlockEntityTypes {
                             CCBlocks.COPYCAT_FENCE_GATE,
                             CCBlocks.COPYCAT_TRAPDOOR,
                             CCBlocks.COPYCAT_IRON_TRAPDOOR,
+                            CCBlocks.COPYCAT_REDSTONE_LAMP,
                             CCBlocks.COPYCAT_WALL,
                             CCBlocks.COPYCAT_GHOST_BLOCK,
                             CCBlocks.COPYCAT_LADDER,

--- a/common/src/main/java/com/copycatsplus/copycats/CCBlocks.java
+++ b/common/src/main/java/com/copycatsplus/copycats/CCBlocks.java
@@ -9,6 +9,8 @@ import com.copycatsplus.copycats.content.copycat.cogwheel.CopycatCogWheelModelCo
 import com.copycatsplus.copycats.content.copycat.cogwheel.CopycatLargeCogWheelModelCore;
 import com.copycatsplus.copycats.content.copycat.flat_pane.CopycatFlatPaneBlock;
 import com.copycatsplus.copycats.content.copycat.flat_pane.CopycatFlatPaneModelCore;
+import com.copycatsplus.copycats.content.copycat.redstone_lamp.CopycatRedstoneLampBlock;
+import com.copycatsplus.copycats.content.copycat.redstone_lamp.CopycatRedstoneLampBlockModelCore;
 import com.copycatsplus.copycats.content.copycat.shaft.CopycatShaftModelCore;
 import com.copycatsplus.copycats.content.copycat.sliding_door.CopycatFoldingDoorModelCore;
 import com.copycatsplus.copycats.content.copycat.sliding_door.CopycatSlidingDoorBlock;
@@ -106,9 +108,9 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.PressurePlateBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.MapColor;
 
 import java.util.HashSet;
@@ -574,6 +576,20 @@ public class CCBlocks {
                             CopycatCharacteristics.FUNCTIONAL
                     ))
                     .transform(customItemModel("copycat_base", "trapdoor"))
+                    .register();
+
+    public static final BlockEntry<CopycatRedstoneLampBlock> COPYCAT_REDSTONE_LAMP =
+            REGISTRATE.block("copycat_redstone_lamp", CopycatRedstoneLampBlock::new)
+                    .transform(CCBuilderTransformers.copycat())
+                    .transform(FeatureToggle.register(FeatureCategory.FUNCTIONAL))
+                    .properties(p -> p.lightLevel(state -> state.getValue(BlockStateProperties.LIT) ? 15 : 0))
+                    .onRegister(onClient(() -> createBlockModel(CopycatRedstoneLampBlockModelCore::new)))
+                    .item()
+                    .onRegister(CopycatDescription.register(
+                            CopycatCharacteristics.COPYCAT,
+                            CopycatCharacteristics.CT_TOGGLE
+                    ))
+                    .transform(customItemModel("copycat_base", "block"))
                     .register();
 
     public static final BlockEntry<CopycatVerticalSliceBlock> COPYCAT_VERTICAL_SLICE =

--- a/common/src/main/java/com/copycatsplus/copycats/CCCreativeTabs.java
+++ b/common/src/main/java/com/copycatsplus/copycats/CCCreativeTabs.java
@@ -61,6 +61,7 @@ public class CCCreativeTabs {
             CCBlocks.COPYCAT_FOLDING_DOOR,
             CCBlocks.COPYCAT_TRAPDOOR,
             CCBlocks.COPYCAT_IRON_TRAPDOOR,
+            CCBlocks.COPYCAT_REDSTONE_LAMP,
             CCBlocks.COPYCAT_FENCE_GATE,
             CCBlocks.COPYCAT_WOODEN_BUTTON,
             CCBlocks.COPYCAT_STONE_BUTTON,

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/cogwheel/CopycatCogWheelBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/cogwheel/CopycatCogWheelBlockEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -18,6 +19,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public class CopycatCogWheelBlockEntity extends BracketedKineticBlockEntity implements IMultiStateCopycatBlockEntity {
+    protected ItemStack lightItem;
     private MaterialItemStorage storage;
 
     public CopycatCogWheelBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
@@ -33,6 +35,16 @@ public class CopycatCogWheelBlockEntity extends BracketedKineticBlockEntity impl
     @Override
     public void setMaterialItemStorageInternal(MaterialItemStorage storage) {
         this.storage = storage;
+    }
+
+    @Override
+    public ItemStack getLightItem() {
+        return lightItem;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/fluid_pipe/CopycatFluidPipeBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/fluid_pipe/CopycatFluidPipeBlockEntity.java
@@ -1,7 +1,6 @@
 package com.copycatsplus.copycats.content.copycat.fluid_pipe;
 
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlockEntity;
-import com.copycatsplus.copycats.foundation.copycat.multistate.IMultiStateCopycatBlockEntity;
 import com.simibubi.create.content.contraptions.StructureTransform;
 import com.simibubi.create.content.fluids.pipes.FluidPipeBlockEntity;
 import com.simibubi.create.content.schematics.requirement.ItemRequirement;
@@ -17,6 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 public class CopycatFluidPipeBlockEntity extends FluidPipeBlockEntity implements ICopycatBlockEntity {
 
     protected BlockState material;
+    protected ItemStack lightItem;
     protected ItemStack consumedItem;
     protected boolean enableCT;
 
@@ -28,6 +28,11 @@ public class CopycatFluidPipeBlockEntity extends FluidPipeBlockEntity implements
     @Override
     public BlockState getMaterial() {
         return material;
+    }
+
+    @Override
+    public ItemStack getLightItem() {
+        return lightItem;
     }
 
     @Override
@@ -43,6 +48,11 @@ public class CopycatFluidPipeBlockEntity extends FluidPipeBlockEntity implements
     @Override
     public void setMaterialInternal(BlockState material) {
         this.material = material;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/fluid_pipe/CopycatStraightPipeBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/fluid_pipe/CopycatStraightPipeBlockEntity.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockState;
 public class CopycatStraightPipeBlockEntity extends StraightPipeBlockEntity implements ICopycatBlockEntity {
 
     protected BlockState material;
+    protected ItemStack lightItem;
     protected ItemStack consumedItem;
     protected boolean enableCT;
 
@@ -25,6 +26,11 @@ public class CopycatStraightPipeBlockEntity extends StraightPipeBlockEntity impl
     @Override
     public BlockState getMaterial() {
         return material;
+    }
+
+    @Override
+    public ItemStack getLightItem() {
+        return lightItem;
     }
 
     @Override
@@ -40,6 +46,11 @@ public class CopycatStraightPipeBlockEntity extends StraightPipeBlockEntity impl
     @Override
     public void setMaterialInternal(BlockState material) {
         this.material = material;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/redstone_lamp/CopycatRedstoneLampBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/redstone_lamp/CopycatRedstoneLampBlock.java
@@ -1,0 +1,128 @@
+package com.copycatsplus.copycats.content.copycat.redstone_lamp;
+
+import com.copycatsplus.copycats.CCBlockEntityTypes;
+import com.copycatsplus.copycats.foundation.copycat.CCCopycatBlock;
+import com.copycatsplus.copycats.foundation.copycat.CCCopycatBlockEntity;
+import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
+import com.copycatsplus.copycats.foundation.copycat.IStateType;
+import com.copycatsplus.copycats.utility.InteractionUtils;
+import com.simibubi.create.content.contraptions.StructureTransform;
+import com.simibubi.create.foundation.block.IBE;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.RedstoneLampBlock;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.TrapDoorBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.pathfinder.PathComputationType;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+public class CopycatRedstoneLampBlock extends RedstoneLampBlock implements ICopycatBlock, IBE<CCCopycatBlockEntity>, IStateType {
+
+    public CopycatRedstoneLampBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Nullable
+    @Override
+    public <S extends BlockEntity> BlockEntityTicker<S> getTicker(Level level, BlockState state, BlockEntityType<S> type) {
+        return null;
+    }
+
+    @Override
+    public InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+        return InteractionUtils.sequential(
+                () -> ICopycatBlock.super.useWithoutItem(state, level, pos, player, hitResult),
+                () -> super.useWithoutItem(state, level, pos, player, hitResult)
+        );
+    }
+
+    @Override
+    public ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
+        return InteractionUtils.sequentialItem(
+                () -> ICopycatBlock.super.useItemOn(stack, state, level, pos, player, hand, hitResult),
+                () -> super.useItemOn(stack, state, level, pos, player, hand, hitResult)
+        );
+    }
+
+    @Override
+    public void setPlacedBy(Level pLevel, BlockPos pPos, BlockState pState, @Nullable LivingEntity pPlacer, ItemStack pStack) {
+        ICopycatBlock.super.setPlacedBy(pLevel, pPos, pState, pPlacer, pStack);
+        super.setPlacedBy(pLevel, pPos, pState, pPlacer, pStack);
+    }
+
+    @Override
+    public void onRemove(BlockState pState, Level pLevel, BlockPos pPos, BlockState pNewState, boolean pIsMoving) {
+        ICopycatBlock.super.onRemove(pState, pLevel, pPos, pNewState, pIsMoving, super::onRemove);
+    }
+
+    @Override
+    public BlockState playerWillDestroy(Level pLevel, BlockPos pPos, BlockState pState, Player pPlayer) {
+        ICopycatBlock.super.playerWillDestroy(pLevel, pPos, pState, pPlayer);
+        super.playerWillDestroy(pLevel, pPos, pState, pPlayer);
+        return pState;
+    }
+
+    @Override
+    public Class<CCCopycatBlockEntity> getBlockEntityClass() {
+        return CCCopycatBlockEntity.class;
+    }
+
+    @Override
+    public BlockEntityType<? extends CCCopycatBlockEntity> getBlockEntityType() {
+        return CCBlockEntityTypes.COPYCAT.get();
+    }
+
+    @Override
+    public @NotNull BlockState rotate(@NotNull BlockState state, Rotation rot) {
+        return ICopycatBlock.super.rotate(state, rot);
+    }
+
+    @Override
+    public @NotNull BlockState mirror(@NotNull BlockState state, Mirror mirror) {
+        return ICopycatBlock.super.mirror(state, mirror);
+    }
+
+
+    @Override
+    public boolean canUseLightItem(ItemStack stack) {
+        return false;
+    }
+
+    public boolean supportsExternalFaceHiding(BlockState state) {
+        return true;
+    }
+
+    public boolean hidesNeighborFace(BlockGetter level,
+                                     BlockPos pos,
+                                     BlockState state,
+                                     BlockState neighborState,
+                                     Direction dir) {
+        return ICopycatBlock.hidesNeighborFace(level, pos, state, neighborState, dir);
+    }
+}

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/redstone_lamp/CopycatRedstoneLampBlockModelCore.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/redstone_lamp/CopycatRedstoneLampBlockModelCore.java
@@ -1,0 +1,13 @@
+package com.copycatsplus.copycats.content.copycat.redstone_lamp;
+
+import com.copycatsplus.copycats.foundation.copycat.model.CopycatModelCore;
+import com.copycatsplus.copycats.foundation.copycat.model.assembly.CopycatRenderContext;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class CopycatRedstoneLampBlockModelCore extends CopycatModelCore {
+
+    @Override
+    public void emitCopycatQuads(String key, BlockState state, CopycatRenderContext context, BlockState material) {
+        context.assembleAll(); // assemble without any modifications
+    }
+}

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/shaft/CopycatShaftBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/shaft/CopycatShaftBlockEntity.java
@@ -15,6 +15,8 @@ import net.minecraft.world.level.block.state.BlockState;
 public class CopycatShaftBlockEntity extends BracketedKineticBlockEntity implements ICopycatBlockEntity {
 
     protected BlockState material;
+    protected ItemStack lightItem;
+
     protected ItemStack consumedItem;
     protected boolean enableCT;
 
@@ -26,6 +28,11 @@ public class CopycatShaftBlockEntity extends BracketedKineticBlockEntity impleme
     @Override
     public BlockState getMaterial() {
         return material;
+    }
+
+    @Override
+    public ItemStack getLightItem() {
+        return lightItem;
     }
 
     @Override
@@ -41,6 +48,11 @@ public class CopycatShaftBlockEntity extends BracketedKineticBlockEntity impleme
     @Override
     public void setMaterialInternal(BlockState material) {
         this.material = material;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/content/copycat/sliding_door/CopycatSlidingDoorBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/content/copycat/sliding_door/CopycatSlidingDoorBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.block.state.BlockState;
 public class CopycatSlidingDoorBlockEntity extends SlidingDoorBlockEntity implements ICopycatBlockEntity {
 
     protected BlockState material;
+    protected ItemStack lightItem;
     protected ItemStack consumedItem;
     protected boolean enableCT;
 
@@ -40,6 +41,11 @@ public class CopycatSlidingDoorBlockEntity extends SlidingDoorBlockEntity implem
     }
 
     @Override
+    public ItemStack getLightItem() {
+        return lightItem;
+    }
+
+    @Override
     public ItemStack getConsumedItem() {
         return consumedItem;
     }
@@ -52,6 +58,11 @@ public class CopycatSlidingDoorBlockEntity extends SlidingDoorBlockEntity implem
     @Override
     public void setMaterialInternal(BlockState material) {
         this.material = material;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/datagen/recipes/CCStandardRecipes.java
+++ b/common/src/main/java/com/copycatsplus/copycats/datagen/recipes/CCStandardRecipes.java
@@ -115,6 +115,8 @@ public class CCStandardRecipes extends CopycatsRecipeProvider {
 
     GeneratedRecipe COPYCAT_IRON_TRAPDOOR = copycat(CCBlocks.COPYCAT_IRON_TRAPDOOR, 2);
 
+    GeneratedRecipe COPYCAT_REDSTONE_LAMP = copycatWithBaseItem(Items.REDSTONE_LAMP, CCBlocks.COPYCAT_REDSTONE_LAMP, 1);
+
     GeneratedRecipe COPYCAT_TRAPDOOR_CYCLE = conversionCycle(AllBlocks.COPYCAT_PANEL, CCBlocks.COPYCAT_TRAPDOOR);
 
     GeneratedRecipe COPYCAT_WALL = copycat(CCBlocks.COPYCAT_WALL, 1);

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/CCCopycatBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/CCCopycatBlockEntity.java
@@ -6,7 +6,6 @@ import com.simibubi.create.content.schematics.requirement.ItemRequirement;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 
-import com.simibubi.create.foundation.virtualWorld.VirtualRenderWorld;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderGetter;
@@ -33,6 +32,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class CCCopycatBlockEntity extends SmartBlockEntity implements ICopycatBlockEntity {
 
     protected BlockState material;
+    protected ItemStack lightItem;
     protected ItemStack consumedItem;
     protected boolean enableCT;
 
@@ -71,6 +71,11 @@ public class CCCopycatBlockEntity extends SmartBlockEntity implements ICopycatBl
     }
 
     @Override
+    public ItemStack getLightItem() {
+        return lightItem;
+    }
+
+    @Override
     public ItemStack getConsumedItem() {
         return consumedItem;
     }
@@ -78,6 +83,11 @@ public class CCCopycatBlockEntity extends SmartBlockEntity implements ICopycatBl
     @Override
     public boolean isCTEnabled() {
         return enableCT;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/ICopycatBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/ICopycatBlock.java
@@ -21,6 +21,7 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -29,7 +30,9 @@ import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.*;
 import net.minecraft.world.level.block.*;
@@ -136,16 +139,33 @@ public interface ICopycatBlock extends IWrenchable, IStateType, TransformableBlo
         if (copycatBE == null)
             return InteractionResult.PASS;
         ItemStack consumedItem = copycatBE.getConsumedItem();
-        if (!copycatBE.hasCustomMaterial())
+        ItemStack lightItem = copycatBE.getLightItem();
+
+        boolean hasConsumedItem = !consumedItem.isEmpty();
+        boolean hasLightItem = !lightItem.isEmpty();
+
+        if (!copycatBE.hasCustomMaterial() && !hasLightItem)
             return InteractionResult.PASS;
+
         Player player = context.getPlayer();
-        if (!player.isCreative())
-            player.getInventory()
-                    .placeItemBackInInventory(consumedItem);
-        context.getLevel()
-                .levelEvent(2001, context.getClickedPos(), Block.getId(getMaterial(context.getLevel(), context.getClickedPos())));
+        if (!player.isCreative()) {
+            if (hasConsumedItem)
+                player.getInventory().placeItemBackInInventory(consumedItem);
+            if (hasLightItem)
+                player.getInventory().placeItemBackInInventory(lightItem);
+        }
+
+        if (hasConsumedItem)
+            context.getLevel()
+                    .levelEvent(2001, context.getClickedPos(), Block.getId(getMaterial(context.getLevel(), context.getClickedPos())));
+        else if (hasLightItem) {
+            SoundEvent soundEvent = ((BlockItem) lightItem.getItem()).getBlock().defaultBlockState().getSoundType().getBreakSound();
+            context.getLevel().playSound(null, copycatBE.getBlockPos(), soundEvent, SoundSource.BLOCKS, 1, .75f);
+        }
+
         copycatBE.setMaterial(AllBlocks.COPYCAT_BASE.getDefaultState());
         copycatBE.setConsumedItem(ItemStack.EMPTY);
+        copycatBE.setLightItem(ItemStack.EMPTY);
         return InteractionResult.SUCCESS;
     }
 
@@ -231,6 +251,9 @@ public interface ICopycatBlock extends IWrenchable, IStateType, TransformableBlo
         if (player == null || !player.mayBuild())
             return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
 
+        ItemInteractionResult lightItemInteractionResult = useLightItemOn(stack, state, level, pos, player, hand, hitResult);
+        if(lightItemInteractionResult != null) return lightItemInteractionResult;
+
         Direction face = hitResult.getDirection();
         BlockState materialIn = getAcceptedBlockState(level, pos, stack, face);
 
@@ -263,6 +286,45 @@ public interface ICopycatBlock extends IWrenchable, IStateType, TransformableBlo
                 .playSound(null, copycatBE.getBlockPos(), material.getSoundType()
                         .getPlaceSound(), SoundSource.BLOCKS, 1, .75f);
 
+        if (player.isCreative())
+            return ItemInteractionResult.SUCCESS;
+
+        stack.shrink(1);
+        if (stack.isEmpty())
+            player.setItemInHand(hand, ItemStack.EMPTY);
+        return ItemInteractionResult.SUCCESS;
+    }
+
+    default boolean canUseLightItem(ItemStack stack) {
+        return stack.is(Items.GLOWSTONE) || stack.is(Items.TORCH) || stack.is(Items.SOUL_TORCH);
+    }
+
+    default @Nullable ItemInteractionResult useLightItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
+        if (!canUseLightItem(stack)) {
+            return null;
+        }
+
+        ICopycatBlockEntity copycatBE = getCopycatBlockEntity(level, pos);
+
+        if (copycatBE == null)
+            return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+
+        if (copycatBE.getLightItem().is(stack.getItem())) {
+            if (!player.isCreative())
+                player.getInventory().placeItemBackInInventory(copycatBE.getLightItem());
+
+            SoundEvent soundEvent = ((BlockItem) stack.getItem()).getBlock().defaultBlockState().getSoundType().getBreakSound();
+            level.playSound(null, copycatBE.getBlockPos(), soundEvent, SoundSource.BLOCKS, 1, .75f);
+            copycatBE.setLightItem(ItemStack.EMPTY);
+            return ItemInteractionResult.SUCCESS;
+        }
+
+        if(!copycatBE.getLightItem().isEmpty() && !player.isCreative())
+            player.getInventory().placeItemBackInInventory(copycatBE.getLightItem());
+
+        copycatBE.setLightItem(stack);
+        SoundEvent soundEvent = ((BlockItem) stack.getItem()).getBlock().defaultBlockState().getSoundType().getPlaceSound();
+        level.playSound(null, copycatBE.getBlockPos(), soundEvent, SoundSource.BLOCKS, 1, .75f);
         if (player.isCreative())
             return ItemInteractionResult.SUCCESS;
 
@@ -322,7 +384,11 @@ public interface ICopycatBlock extends IWrenchable, IStateType, TransformableBlo
     default BlockState playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
         if (player.isCreative()) {
             ICopycatBlockEntity copycatBE = getCopycatBlockEntity(level, pos);
-            if (copycatBE != null) copycatBE.setConsumedItem(ItemStack.EMPTY);
+            if (copycatBE != null) {
+                copycatBE.setConsumedItem(ItemStack.EMPTY);
+                copycatBE.setLightItem(ItemStack.EMPTY);
+            }
+
         }
         return state;
     }

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/ICopycatBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/ICopycatBlockEntity.java
@@ -20,14 +20,13 @@ import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.ApiStatus;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -67,12 +66,17 @@ public interface ICopycatBlockEntity extends SpecialBlockEntityItemRequirement, 
 
     BlockState getMaterial();
 
+    ItemStack getLightItem();
+
     ItemStack getConsumedItem();
 
     boolean isCTEnabled();
 
     @ApiStatus.OverrideOnly
     void setMaterialInternal(BlockState material);
+
+    @ApiStatus.OverrideOnly
+    void setLightItemInternal(ItemStack stack);
 
     @ApiStatus.OverrideOnly
     void setConsumedItemInternal(ItemStack consumedItem);
@@ -86,6 +90,7 @@ public interface ICopycatBlockEntity extends SpecialBlockEntityItemRequirement, 
     default void init() {
         setMaterialInternal(AllBlocks.COPYCAT_BASE.getDefaultState());
         setConsumedItemInternal(ItemStack.EMPTY);
+        setLightItem(ItemStack.EMPTY);
         setCTEnabledInternal(true);
     }
 
@@ -155,6 +160,21 @@ public interface ICopycatBlockEntity extends SpecialBlockEntityItemRequirement, 
         return true;
     }
 
+    default int getLightLevel() {
+        ItemStack lightItem = getLightItem();
+
+        if(lightItem.is(Items.GLOWSTONE)) return 15;
+        if(lightItem.is(Items.TORCH)) return 14;
+        if(lightItem.is(Items.SOUL_TORCH)) return 7;
+        return -1;
+    }
+
+    default void setLightItem(ItemStack stack) {
+        setLightItemInternal(ItemUtils.copyStackWithSize(stack, 1));
+
+        BlockEntityUtils.redraw((BlockEntity) this);
+    }
+
     default void setConsumedItem(ItemStack stack) {
         setConsumedItemInternal(ItemUtils.copyStackWithSize(stack, 1));
         notifyUpdate();
@@ -196,6 +216,8 @@ public interface ICopycatBlockEntity extends SpecialBlockEntityItemRequirement, 
 
         self.setConsumedItem(ItemStack.parseOptional(registries, (tag.getCompound("Item"))));
 
+        self.setLightItem(ItemStack.parseOptional(registries, tag.getCompound("LightItem")));
+
         BlockState prevMaterial = self.getMaterial();
         if (!tag.contains("Material")) {
             self.setConsumedItem(ItemStack.EMPTY);
@@ -225,18 +247,21 @@ public interface ICopycatBlockEntity extends SpecialBlockEntityItemRequirement, 
     static void writeSafe(ICopycatBlockEntity self, CompoundTag tag, HolderLookup.Provider registries) {
         ItemStack stackWithoutNBT = self.getConsumedItem().copy();
         ItemStack stackWithoutComponents = new ItemStack(stackWithoutNBT.getItemHolder(), stackWithoutNBT.getCount(), DataComponentPatch.EMPTY);
+        ItemStack lightItemWithoutNBT = self.getConsumedItem().copy();
+        ItemStack lightItemWithoutComponents = new ItemStack(lightItemWithoutNBT.getItemHolder(), lightItemWithoutNBT.getCount(), DataComponentPatch.EMPTY);
         BlockEntityUtils.saveMetadata((BlockEntity) self, tag);
-        write(tag, stackWithoutComponents, self.getMaterial(), registries, self.isCTEnabled());
+        write(tag, stackWithoutComponents, self.getMaterial(), lightItemWithoutComponents, registries, self.isCTEnabled());
     }
 
     static void write(ICopycatBlockEntity self, CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
-        write(tag, self.getConsumedItem(), self.getMaterial(), registries, self.isCTEnabled());
+        write(tag, self.getConsumedItem(), self.getMaterial(), self.getLightItem(), registries, self.isCTEnabled());
     }
 
     @ApiStatus.Internal
-    static void write(CompoundTag tag, ItemStack stack, BlockState material, HolderLookup.Provider registries, boolean enableCT) {
+    static void write(CompoundTag tag, ItemStack stack, BlockState material, ItemStack lightItem, HolderLookup.Provider registries, boolean enableCT) {
         tag.put("Item", ItemUtils.serializeNBT(stack, registries));
         tag.put("Material", NbtUtils.writeBlockState(material));
+        tag.put("LightItem", ItemUtils.serializeNBT(lightItem, registries));
         tag.putBoolean("EnableCT", enableCT);
     }
 }

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlock.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlock.java
@@ -3,10 +3,7 @@ package com.copycatsplus.copycats.foundation.copycat.multistate;
 import com.copycatsplus.copycats.CCKeys;
 import com.copycatsplus.copycats.compat.AthenaCompat;
 import com.copycatsplus.copycats.compat.Mods;
-import com.copycatsplus.copycats.foundation.copycat.ICopycatBlock;
-import com.copycatsplus.copycats.foundation.copycat.IStateType;
-import com.copycatsplus.copycats.foundation.copycat.CopycatExternalContext;
-import com.copycatsplus.copycats.foundation.copycat.StateType;
+import com.copycatsplus.copycats.foundation.copycat.*;
 import com.copycatsplus.copycats.foundation.copycat.model.ScaledBlockAndTintGetter;
 import com.copycatsplus.copycats.network.CCPackets;
 import com.copycatsplus.copycats.network.FillCopycatPacket;
@@ -26,6 +23,7 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -33,6 +31,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.UseOnContext;
@@ -234,18 +233,37 @@ public interface IMultiStateCopycatBlock extends ICopycatBlock, IStateType {
             }
         }
 
-        if (!copycatBE.getMaterialItemStorage().hasCustomMaterial(property))
+        ItemStack lightItem = copycatBE.getLightItem();
+
+        boolean hasConsumedItem = !consumedItem.isEmpty();
+        boolean hasCustomMaterial = copycatBE.getMaterialItemStorage().hasCustomMaterial(property);
+        boolean hasLightItem = !lightItem.isEmpty();
+
+        if (!hasCustomMaterial && !hasLightItem)
             return InteractionResult.PASS;
 
         Player player = context.getPlayer();
-        if (!player.isCreative())
-            player.getInventory()
-                    .placeItemBackInInventory(consumedItem);
-        context.getLevel()
-                .levelEvent(2001, context.getClickedPos(), Block.getId(material.material()));
+        if (!player.isCreative()) {
+            if (hasConsumedItem)
+                player.getInventory().placeItemBackInInventory(consumedItem);
+            if (hasLightItem)
+                player.getInventory().placeItemBackInInventory(lightItem);
+        }
+
+        if (hasConsumedItem)
+            context.getLevel()
+                    .levelEvent(2001, context.getClickedPos(), Block.getId(material.material()));
+        else if (hasCustomMaterial) {
+            SoundEvent soundEvent = material.material().getSoundType().getBreakSound();
+            context.getLevel().playSound(null, copycatBE.getBlockPos(), soundEvent, SoundSource.BLOCKS, 1, .75f);
+        } else {
+            SoundEvent soundEvent = ((BlockItem) lightItem.getItem()).getBlock().defaultBlockState().getSoundType().getBreakSound();
+            context.getLevel().playSound(null, copycatBE.getBlockPos(), soundEvent, SoundSource.BLOCKS, 1, .75f);
+        }
 
         copycatBE.setMaterial(property, AllBlocks.COPYCAT_BASE.getDefaultState());
         copycatBE.setConsumedItem(property, ItemStack.EMPTY);
+        copycatBE.setLightItem(ItemStack.EMPTY);
         return InteractionResult.SUCCESS;
     }
 
@@ -267,6 +285,9 @@ public interface IMultiStateCopycatBlock extends ICopycatBlock, IStateType {
 
         if (player == null || !player.mayBuild())
             return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+
+        ItemInteractionResult lightItemInteractionResult = useLightItemOn(stack, state, level, pos, player, hand, hitResult);
+        if(lightItemInteractionResult != null) return lightItemInteractionResult;
 
         String property = getPropertyFromInteraction(state, level, pos, hitResult, true);
 

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/IMultiStateCopycatBlockEntity.java
@@ -2,6 +2,7 @@ package com.copycatsplus.copycats.foundation.copycat.multistate;
 
 import com.copycatsplus.copycats.foundation.copycat.ICopycatBlockEntity;
 import com.copycatsplus.copycats.utility.BlockEntityUtils;
+import com.copycatsplus.copycats.utility.ItemUtils;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.contraptions.StructureTransform;
 import com.simibubi.create.content.redstone.RoseQuartzLampBlock;
@@ -12,6 +13,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Vec3i;
+import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockAndTintGetter;
@@ -60,6 +62,7 @@ public interface IMultiStateCopycatBlockEntity extends ICopycatBlockEntity {
         } else {
             setMaterialItemStorageInternal(MaterialItemStorage.create(Set.of("block")));
         }
+        setLightItemInternal(ItemStack.EMPTY);
     }
 
     @Override
@@ -234,6 +237,8 @@ public interface IMultiStateCopycatBlockEntity extends ICopycatBlockEntity {
     @Override
     default void transform(BlockEntity blockEntity, StructureTransform transform) {
         getBlock().transformStorage(this.getBlockState(), this, transform);
+
+
         for (String key : getMaterialItemStorage().getAllProperties()) {
             getMaterialItemStorage().getMaterialItem(key).setMaterial(transform.apply(getMaterialItemStorage().getMaterialItem(key).material()));
         }
@@ -241,6 +246,8 @@ public interface IMultiStateCopycatBlockEntity extends ICopycatBlockEntity {
     }
 
     static void read(IMultiStateCopycatBlockEntity self, CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
+        self.setLightItem(ItemStack.parseOptional(registries, tag.getCompound("LightItem")));
+
         if (self.getBlockState().getBlock() instanceof IMultiStateCopycatBlock) {
             boolean anyUpdated = self.getMaterialItemStorage().deserialize(tag.getCompound("material_data"), registries);
 
@@ -250,11 +257,15 @@ public interface IMultiStateCopycatBlockEntity extends ICopycatBlockEntity {
     }
 
     static void writeSafe(IMultiStateCopycatBlockEntity self, CompoundTag tag, HolderLookup.Provider registries) {
+        ItemStack lightItemWithoutNBT = self.getConsumedItem().copy();
+        ItemStack lightItemWithoutComponents = new ItemStack(lightItemWithoutNBT.getItemHolder(), lightItemWithoutNBT.getCount(), DataComponentPatch.EMPTY);
         BlockEntityUtils.saveMetadata((BlockEntity) self, tag);
         tag.put("material_data", self.getMaterialItemStorage().serializeSafe(registries));
+        tag.put("LightItem", ItemUtils.serializeNBT(lightItemWithoutComponents, registries));
     }
 
     static void write(IMultiStateCopycatBlockEntity self, CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         tag.put("material_data", self.getMaterialItemStorage().serialize(registries));
+        tag.put("LightItem", ItemUtils.serializeNBT(self.getLightItem(), registries));
     }
 }

--- a/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/MultiStateCopycatBlockEntity.java
+++ b/common/src/main/java/com/copycatsplus/copycats/foundation/copycat/multistate/MultiStateCopycatBlockEntity.java
@@ -30,6 +30,7 @@ import java.util.List;
 @MethodsReturnNonnullByDefault
 public class MultiStateCopycatBlockEntity extends SmartBlockEntity implements IMultiStateCopycatBlockEntity {
 
+    protected ItemStack lightItem;
     private MaterialItemStorage materialItemStorage;
 
     public MultiStateCopycatBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
@@ -44,6 +45,16 @@ public class MultiStateCopycatBlockEntity extends SmartBlockEntity implements IM
     @Override
     public void setMaterialItemStorageInternal(MaterialItemStorage storage) {
         materialItemStorage = storage;
+    }
+
+    @Override
+    public ItemStack getLightItem() {
+        return lightItem;
+    }
+
+    @Override
+    public void setLightItemInternal(ItemStack stack) {
+        this.lightItem = stack;
     }
 
     @Override

--- a/common/src/main/java/com/copycatsplus/copycats/utility/BlockEntityUtils.java
+++ b/common/src/main/java/com/copycatsplus/copycats/utility/BlockEntityUtils.java
@@ -7,6 +7,7 @@ import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -46,12 +47,20 @@ public class BlockEntityUtils {
 
     public static int getLightEmission(BlockEntity blockEntity) {
         if (blockEntity instanceof IMultiStateCopycatBlockEntity multiStateBE) {
-            int light = 0;
+            int lightLevelFromItem = multiStateBE.getLightLevel();
+            int light = Math.max(lightLevelFromItem, 0);
             for (BlockState material : multiStateBE.getMaterialItemStorage().getAllMaterials()) {
                 light = Math.max(light, material.getLightEmission(multiStateBE.getLevel(), multiStateBE.getBlockPos()));
             }
             return light;
         } else if (blockEntity instanceof ICopycatBlockEntity copycatBE) {
+            if (copycatBE.getBlock() instanceof RedstoneLampBlock redstoneLampBlock && blockEntity.getLevel() != null) {
+                return redstoneLampBlock.getLightEmission(copycatBE.getBlockState(), blockEntity.getLevel(), blockEntity.getBlockPos());
+            }
+
+            int lightLevel = copycatBE.getLightLevel();
+            if(lightLevel != -1) return lightLevel;
+
             return copycatBE.getMaterial().getLightEmission(copycatBE.getLevel(), copycatBE.getBlockPos());
         }
         return 0;

--- a/neoforge/src/generated/resources/assets/copycats/blockstates/copycat_redstone_lamp.json
+++ b/neoforge/src/generated/resources/assets/copycats/blockstates/copycat_redstone_lamp.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/air"
+    }
+  }
+}

--- a/neoforge/src/generated/resources/assets/copycats/lang/en_ud.json
+++ b/neoforge/src/generated/resources/assets/copycats/lang/en_ud.json
@@ -25,6 +25,7 @@
   "block.copycats.copycat_layer": "ɹǝʎɐꞀ ʇɐɔʎdoƆ",
   "block.copycats.copycat_light_weighted_pressure_plate": "ǝʇɐןԀ ǝɹnssǝɹԀ pǝʇɥbıǝM ʇɥbıꞀ ʇɐɔʎdoƆ",
   "block.copycats.copycat_pane": "ǝuɐԀ ʇɐɔʎdoƆ",
+  "block.copycats.copycat_redstone_lamp": "dɯɐꞀ ǝuoʇspǝᴚ ʇɐɔʎdoƆ",
   "block.copycats.copycat_shaft": "ʇɟɐɥS ʇɐɔʎdoƆ",
   "block.copycats.copycat_slab": "qɐןS ʇɐɔʎdoƆ",
   "block.copycats.copycat_slice": "ǝɔıןS ʇɐɔʎdoƆ",

--- a/neoforge/src/generated/resources/assets/copycats/lang/en_us.json
+++ b/neoforge/src/generated/resources/assets/copycats/lang/en_us.json
@@ -25,6 +25,7 @@
   "block.copycats.copycat_layer": "Copycat Layer",
   "block.copycats.copycat_light_weighted_pressure_plate": "Copycat Light Weighted Pressure Plate",
   "block.copycats.copycat_pane": "Copycat Pane",
+  "block.copycats.copycat_redstone_lamp": "Copycat Redstone Lamp",
   "block.copycats.copycat_shaft": "Copycat Shaft",
   "block.copycats.copycat_slab": "Copycat Slab",
   "block.copycats.copycat_slice": "Copycat Slice",

--- a/neoforge/src/generated/resources/assets/copycats/models/item/copycat_redstone_lamp.json
+++ b/neoforge/src/generated/resources/assets/copycats/models/item/copycat_redstone_lamp.json
@@ -1,0 +1,3 @@
+{
+  "parent": "copycats:block/copycat_base/block"
+}

--- a/neoforge/src/generated/resources/data/copycats/advancement/recipes/misc/crafting/copycat_redstone_lamp.json
+++ b/neoforge/src/generated/resources/data/copycats/advancement/recipes/misc/crafting/copycat_redstone_lamp.json
@@ -1,0 +1,39 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "copycats:feature_enabled",
+      "feature": "copycats:copycat_redstone_lamp",
+      "invert": false
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_item": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:redstone_lamp"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "copycats:crafting/copycat_redstone_lamp"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_item"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "copycats:crafting/copycat_redstone_lamp"
+    ]
+  }
+}

--- a/neoforge/src/generated/resources/data/copycats/loot_table/blocks/copycat_redstone_lamp.json
+++ b/neoforge/src/generated/resources/data/copycats/loot_table/blocks/copycat_redstone_lamp.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "copycats:copycat_redstone_lamp"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "copycats:blocks/copycat_redstone_lamp"
+}

--- a/neoforge/src/generated/resources/data/copycats/recipe/crafting/copycat_redstone_lamp.json
+++ b/neoforge/src/generated/resources/data/copycats/recipe/crafting/copycat_redstone_lamp.json
@@ -1,0 +1,23 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "copycats:feature_enabled",
+      "feature": "copycats:copycat_redstone_lamp",
+      "invert": false
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "item": "minecraft:redstone_lamp"
+    },
+    {
+      "item": "create:zinc_ingot"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "copycats:copycat_redstone_lamp"
+  }
+}

--- a/neoforge/src/generated/resources/data/minecraft/tags/block/mineable/axe.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/block/mineable/axe.json
@@ -28,6 +28,7 @@
     "copycats:copycat_vertical_stairs",
     "copycats:copycat_trapdoor",
     "copycats:copycat_iron_trapdoor",
+    "copycats:copycat_redstone_lamp",
     "copycats:copycat_vertical_slice",
     "copycats:copycat_vertical_step",
     "copycats:copycat_wall",

--- a/neoforge/src/generated/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/neoforge/src/generated/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -29,6 +29,7 @@
     "copycats:copycat_vertical_stairs",
     "copycats:copycat_trapdoor",
     "copycats:copycat_iron_trapdoor",
+    "copycats:copycat_redstone_lamp",
     "copycats:copycat_vertical_slice",
     "copycats:copycat_vertical_step",
     "copycats:copycat_wall",


### PR DESCRIPTION
Adds an interaction that allows the light level of any copycat to be set to the same light level as that of a torch, a soul torch, or a glowstone block. The items can be removed by right clicking with the same item or by wrenching.

Also creates a redstone lamp copycat.

I tried to create a new model to the redstone lamp copycat, with a redstone lamp inside the usual copycat block, but there doesn't seem to be a easy way to do so without changing the whole rendering system. 